### PR TITLE
Improve ordering of import statements in Java Coding Standard

### DIFF
--- a/codingStandards/CodingStandard-Java.md
+++ b/codingStandards/CodingStandard-Java.md
@@ -385,21 +385,42 @@ The package statement location is enforced by the Java language. A Java package 
 
 The rule of thumb is to package the classes that are related. For example in Java, the classes related to file writing is grouped in the package `java.io` and the classes which handle lists, maps etc are grouped in `java.util` package.
 
-**2. The import statements must follow the package statement. import statements should be sorted with the most fundamental packages first, and grouped with associated packages together and one blank line between groups.**
+**2. The ordering of import statements must be consistent.**
+
+A consistent ordering of import statements makes it easier to browse the list and determine the dependencies when there are many imports.
+
+Major IDEs (e.g. Eclipse and IntelliJ IDEA) have built-in formatters to order the imports. For example, Eclipse uses this default ordering:
+
+- group of static imports is on the top
+- groups of non-static imports: "java" and "javax" packages first, then "org" and "com", then all other imports as one group
+- imports are sorted alphabetically in the groups
+- groups are separated by one blank line
+
+Below is an example of imports organised in Eclipse:
 
 ```java
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-import java.rmi.RmiServer;
-import java.rmi.server.Server;
-import javax.swing.JPanel;
-import javax.swing.event.ActionEvent;
-import org.linux.apache.server.SoapServer;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+import org.loadui.testfx.GuiTest;
+import org.testfx.api.FxToolkit;
+
+import com.google.common.io.Files;
+
+import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
+import junit.framework.AssertionFailedError;
 ```
 
-The import statement location is enforced by the Java language. The sorting makes it simple to browse the list when there are many imports, and it makes it easy to determine the dependencies of the present package. The grouping reduce complexity by collapsing related information into a common unit. 
-
 >*Hint: You can organise the imports automatically by simply pressing CTRL+SHIFT+O in Eclipse.*
+
+However, note that the default orderings of different IDEs are not always the same. It is recommended that you and your team use the same IDE and stick to a consistent ordering.
 
 **3. Imported classes should always be listed explicitly.**
 


### PR DESCRIPTION
From commit message body:

>Java Coding Standard doesn't clearly specify a set of rules to follow
when organizing the import statements.<br>
We make it clear by listing the rules used by Eclipse as an example.
We also inform readers that different IDEs may have different rules,
and there is no right or wrong about which rules they choose to follow,
but the important thing is being consistent.<br>
We are not using other IDE as example because CS2103, SE-EDU and
TEAMMATES are using Eclipse as the primary IDE for now.

Ready for review.

[Preview of import statement section](https://github.com/chao1995/process/blob/java-import-order/codingStandards/CodingStandard-Java.md#package-and-import-statements)