### PR TITLE
PR life cycle: no need to duplicate reviewers as assignees #36

### DIFF
--- a/docs/OverseeingIssuePrLifeCycle.md
+++ b/docs/OverseeingIssuePrLifeCycle.md
@@ -14,24 +14,21 @@ When an issue comes in,
     for change requests (_misc. posts_ do not need priority labels). This is to ensure that all issues get
     prioritized using a uniform scale.
 
-# Assigning reviewers for PRs
+# Requesting reviews for PRs
 
-* A PR should have,
-  * **1 or more `reviewers`** (See [Reviewing PRs](ReviewingPrs.md) for more info)
-  * **all reviewers should be selected as `assignees`**
-  
-  > Duplicating `reviewers` as `assignees` is needed because GitHub filter syntax cannot filter by reviewers yet.
+* A PR should have **1 or more `reviewers`**. See [Reviewing PRs](ReviewingPrs.md).<br>
+  The `assignees` field can be left empty.
   
 * PRs created by core members:
-  * If you can, assign at least one `reviewer`. If you don't, team lead will assign reviewers for the PR.
+  * Author may request a review from a core member. Else, team lead will assign reviewers for the PR.
   
-  > GitHub's _blame_ feature (or a third-party service such as _mentionbot_) can help to find suitable reviewers. 
-  > **Currently active** Developers who have touched the same code before and leads of the areas touched by the PR 
-  > are potential reviewers.
+    > GitHub's _blame_ feature (or a third-party service such as _mentionbot_) can help to find suitable reviewers. 
+    > **Currently active** developers who have touched the same code before and leads of the areas touched by the PR 
+    > are potential reviewers.
   
 * PRs created by non-core members:
-  * Team lead should assign reviewers based on the member's expertise area. 
-  * Core members can volunteer as reviewers by assigning self as a `reviewer` (and `assignee`).
+  * Team lead should request reviews based on the members' areas of expertise. 
+  * Core members can volunteer as reviewers by requesting a review from self.
 
 * After a PR has been approved by all reviewers, the last reviewer to approve should request a 
   review from the PM.


### PR DESCRIPTION
Fixes #36 

```
PR lifecycle requires reviewers to be assigned as 'assignees' of
the PR. This is because GitHub did not have a way to filter PRs by
review requests.

GitHub has added the ability to filter PRs by review requests
https://github.com/blog/2306-filter-pull-request-reviews-and-review-requests

Let's remove the requirement to use the assignees field in PRs to
indicate reviewers.
```