### PR TITLE
FormatsAndConventions: fix broken rendering

### DIFF
--- a/docs/FormatsAndConventions.adoc
+++ b/docs/FormatsAndConventions.adoc
@@ -184,6 +184,7 @@ Build-breaking commits in the version history hinder the ability to use `git bis
 ====
 https://github.com/se-edu/addressbook-level4/pull/237[Here] is an example of a PR that is organized
 as described above.
+====
 +
 [NOTE]
 ====


### PR DESCRIPTION
This missing `====` led to garbled formatting in the rendered HTML.